### PR TITLE
BUG: python2 fails to restore a previously imported numpy

### DIFF
--- a/hide_modules.py
+++ b/hide_modules.py
@@ -22,6 +22,7 @@ class ModuleHider(_ModuleHiderBase):
 
     def __init__(self, hidden):
         self.hidden = hidden
+        self.hidden_modules = {}
 
     # python <=3.3
     def find_module(self, fullname, path=None):
@@ -42,12 +43,15 @@ class ModuleHider(_ModuleHiderBase):
         # remove hidden modules to force reload
         for m in self.hidden:
             if m in sys.modules:
+                self.hidden_modules[m] = sys.modules[m]
                 del sys.modules[m]
 
     def unhide(self):
         "Unhide modules"
         import sys
         sys.meta_path.remove(self)
+        sys.modules.update(self.hidden_modules)
+        self.hidden_modules.clear()
 
     def __enter__(self):
         self.hide()

--- a/test_hide_modules.py
+++ b/test_hide_modules.py
@@ -24,7 +24,7 @@ def blocked_import_wsgiref_handlers():
 
 
 class TestHideModules(unittest.TestCase):
-    
+
     def testHideUnhide(self):
         "Test ModuleHider hide and unhide methods"
         mh = hide_modules.ModuleHider(['csv', 'wsgiref.handlers'])
@@ -61,6 +61,26 @@ class TestHideModules(unittest.TestCase):
         "Test hide_modules applied to test method"
         self.assertRaises(ImportError, import_csv)
         self.assertRaises(ImportError, import_wsgiref_handlers)
+
+    def testRestoringHiddenNumpy(self):
+        """
+        Numpy has a complicated internal import scheme that requires special
+        handling with python 2.7.
+        """
+        def fallback_on_import():
+            try:
+                import numpy
+                self.assertTrue(False)
+            except ImportError:
+                pass
+
+        @hide_modules.hide_modules(['numpy'])
+        def fn():
+            fallback_on_import()
+
+        import numpy
+        fn()
+        import numpy
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Without digging deep into why numpy specifically was having this problem,
see the associated unittest, the ModuleHider now saves off the module from
sys.modules into a local dict and restores it upon unhiding.